### PR TITLE
feat: add basic auth api and client integration

### DIFF
--- a/client/components/CreateListingForm.tsx
+++ b/client/components/CreateListingForm.tsx
@@ -45,8 +45,7 @@ export function CreateListingForm() {
     height: "",
     width: "",
     depth: "",
-    unit: "cm" as "cm" | "inches" | "sqm",
-    squareMeters: "",
+    unit: "cm" as "cm" | "inches",
     condition: "",
     features: [] as string[],
     address: "",
@@ -181,7 +180,6 @@ export function CreateListingForm() {
         width: "",
         depth: "",
         unit: "cm",
-        squareMeters: "",
         condition: "",
         features: [],
         address: "",
@@ -368,64 +366,41 @@ export function CreateListingForm() {
                     <SelectItem value="inches">
                       Height x Width x Depth (inches)
                     </SelectItem>
-                    <SelectItem value="sqm">Square Meters</SelectItem>
                   </SelectContent>
                 </Select>
 
-                {formData.unit === "sqm" ? (
+                <div className="grid grid-cols-3 gap-4">
                   <div>
-                    <Label className="text-sm">Total Square Meters</Label>
+                    <Label className="text-sm">Height</Label>
                     <Input
                       type="number"
-                      placeholder="25.5"
-                      step="0.1"
-                      value={formData.squareMeters}
-                      onChange={(e) =>
-                        handleInputChange("squareMeters", e.target.value)
-                      }
+                      placeholder="56"
+                      value={formData.height}
+                      onChange={(e) => handleInputChange("height", e.target.value)}
                       required
                     />
                   </div>
-                ) : (
-                  <div className="grid grid-cols-3 gap-4">
-                    <div>
-                      <Label className="text-sm">Height</Label>
-                      <Input
-                        type="number"
-                        placeholder="56"
-                        value={formData.height}
-                        onChange={(e) =>
-                          handleInputChange("height", e.target.value)
-                        }
-                        required
-                      />
-                    </div>
-                    <div>
-                      <Label className="text-sm">Width</Label>
-                      <Input
-                        type="number"
-                        placeholder="35"
-                        value={formData.width}
-                        onChange={(e) =>
-                          handleInputChange("width", e.target.value)
-                        }
-                        required
-                      />
-                    </div>
-                    <div>
-                      <Label className="text-sm">Depth</Label>
-                      <Input
-                        type="number"
-                        placeholder="23"
-                        value={formData.depth}
-                        onChange={(e) =>
-                          handleInputChange("depth", e.target.value)
-                        }
-                        required
-                      />
-                    </div>
+                  <div>
+                    <Label className="text-sm">Width</Label>
+                    <Input
+                      type="number"
+                      placeholder="35"
+                      value={formData.width}
+                      onChange={(e) => handleInputChange("width", e.target.value)}
+                      required
+                    />
                   </div>
-                )}
+                  <div>
+                    <Label className="text-sm">Depth</Label>
+                    <Input
+                      type="number"
+                      placeholder="23"
+                      value={formData.depth}
+                      onChange={(e) => handleInputChange("depth", e.target.value)}
+                      required
+                    />
+                  </div>
+                </div>
               </div>
             </div>
 
@@ -717,9 +692,7 @@ export function CreateListingForm() {
                   !formData.type ||
                   !formData.condition)) ||
               (currentStep === 2 &&
-                (formData.unit === "sqm"
-                  ? !formData.squareMeters
-                  : !formData.height || !formData.width || !formData.depth)) ||
+                (!formData.height || !formData.width || !formData.depth)) ||
               (currentStep === 3 &&
                 (!formData.address ||
                   !formData.city ||

--- a/client/contexts/AuthContext.tsx
+++ b/client/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ export interface User {
   avatar?: string;
   joinDate: string;
   isHost: boolean;
+  phoneNumber?: string;
 }
 
 interface AuthContextType {
@@ -35,23 +36,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = async (email: string, password: string) => {
     setIsLoading(true);
     try {
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // Mock successful login
-      const mockUser: User = {
-        id: '1',
-        email,
-        firstName: 'John',
-        lastName: 'Doe',
-        joinDate: new Date().toISOString(),
-        isHost: false
-      };
-      
-      setUser(mockUser);
-      localStorage.setItem('user', JSON.stringify(mockUser));
-    } catch (error) {
-      throw new Error('Login failed');
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Login failed' }));
+        throw new Error(err.error || 'Login failed');
+      }
+
+      const data = await res.json();
+      setUser(data.user);
+      localStorage.setItem('user', JSON.stringify(data.user));
+    } catch (error: any) {
+      throw new Error(error?.message || 'Login failed');
     } finally {
       setIsLoading(false);
     }
@@ -60,23 +60,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signup = async (data: SignupData) => {
     setIsLoading(true);
     try {
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // Mock successful signup
-      const mockUser: User = {
-        id: Math.random().toString(36).substr(2, 9),
-        email: data.email,
-        firstName: data.firstName,
-        lastName: data.lastName,
-        joinDate: new Date().toISOString(),
-        isHost: false
-      };
-      
-      setUser(mockUser);
-      localStorage.setItem('user', JSON.stringify(mockUser));
-    } catch (error) {
-      throw new Error('Signup failed');
+      const res = await fetch('/api/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Signup failed' }));
+        throw new Error(err.error || 'Signup failed');
+      }
+
+      const result = await res.json();
+      setUser(result.user);
+      localStorage.setItem('user', JSON.stringify(result.user));
+    } catch (error: any) {
+      throw new Error(error?.message || 'Signup failed');
     } finally {
       setIsLoading(false);
     }

--- a/client/pages/Account.tsx
+++ b/client/pages/Account.tsx
@@ -19,6 +19,7 @@ import {
   Package,
   TrendingUp,
   Shield,
+  DollarSign,
 } from "lucide-react";
 
 export default function Account() {

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import express from "express";
 import cors from "cors";
 import { handleDemo } from "./routes/demo";
+import { handleLogin, handleSignup } from "./routes/auth";
 
 export function createServer() {
   const app = express();
@@ -18,6 +19,9 @@ export function createServer() {
   });
 
   app.get("/api/demo", handleDemo);
+
+  app.post("/api/login", handleLogin);
+  app.post("/api/signup", handleSignup);
 
   return app;
 }

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,0 +1,75 @@
+import { RequestHandler } from "express";
+import { z } from "zod";
+
+interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  joinDate: string;
+  isHost: boolean;
+  phoneNumber?: string;
+}
+
+const users: User[] = [];
+
+const signupSchema = z.object({
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export const handleSignup: RequestHandler = (req, res) => {
+  const result = signupSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ error: "Invalid signup data" });
+  }
+
+  const exists = users.find((u) => u.email === result.data.email);
+  if (exists) {
+    return res.status(400).json({ error: "User already exists" });
+  }
+
+  const data = result.data;
+  const newUser: User = {
+    id: String(users.length + 1),
+    firstName: data.firstName,
+    lastName: data.lastName,
+    email: data.email,
+    password: data.password,
+    joinDate: new Date().toISOString(),
+    isHost: false,
+  };
+
+  users.push(newUser);
+  res.status(200).json({ user: sanitizeUser(newUser), token: "fake-token" });
+};
+
+export const handleLogin: RequestHandler = (req, res) => {
+  const result = loginSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ error: "Invalid login data" });
+  }
+
+  const user = users.find(
+    (u) => u.email === result.data.email && u.password === result.data.password
+  );
+  if (!user) {
+    return res.status(401).json({ error: "Invalid credentials" });
+  }
+
+  res.status(200).json({ user: sanitizeUser(user), token: "fake-token" });
+};
+
+function sanitizeUser(user: User) {
+  const { password, ...rest } = user;
+  return rest;
+}
+


### PR DESCRIPTION
## Summary
- add `/api/login` and `/api/signup` handlers with simple credential validation
- wire up login/signup routes in express server
- call auth endpoints from AuthContext instead of mock logic

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6892699bfb10832e9675b58905dba03a