### PR TITLE
Sync auth modal tab with default tab

### DIFF
--- a/client/components/AuthModal.tsx
+++ b/client/components/AuthModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
@@ -27,6 +27,12 @@ export function AuthModal({ isOpen, onClose, defaultTab = "login" }: AuthModalPr
   
   const { login, signup, isLoading } = useAuth();
   const { toast } = useToast();
+
+  useEffect(() => {
+    if (isOpen) {
+      setActiveTab(defaultTab);
+    }
+  }, [defaultTab, isOpen]);
 
   const handleInputChange = (field: string, value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));


### PR DESCRIPTION
## Summary
- sync active auth modal tab with provided default tab when modal opens

## Testing
- `npm test`
- `npm run typecheck` *(fails: Type '"cm" | "inches" | "sqm"' is not assignable to type '"cm" | "inches"'; Property 'phoneNumber' does not exist on type 'User'; Cannot find name 'DollarSign')*

------
https://chatgpt.com/codex/tasks/task_e_6892699d267c832eab03952e05308d27