### PR TITLE
feat: add translations

### DIFF
--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -79,7 +79,7 @@ export function Header() {
                 <Button variant="outline" size="sm" asChild>
                   <Link to="/host">
                     <User className="h-4 w-4 mr-2" />
-                    Host
+                    {t('header.host')}
                   </Link>
                 </Button>
                 
@@ -106,25 +106,25 @@ export function Header() {
                     <DropdownMenuItem asChild>
                       <Link to="/account" className="flex items-center">
                         <User className="mr-2 h-4 w-4" />
-                        <span>Account</span>
+                        <span>{t('header.account')}</span>
                       </Link>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>
                       <Link to="/account" className="flex items-center">
                         <Calendar className="mr-2 h-4 w-4" />
-                        <span>My Bookings</span>
+                        <span>{t('header.myBookings')}</span>
                       </Link>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>
                       <Link to="/account" className="flex items-center">
                         <Settings className="mr-2 h-4 w-4" />
-                        <span>Settings</span>
+                        <span>{t('header.settings')}</span>
                       </Link>
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem onClick={logout}>
                       <LogOut className="mr-2 h-4 w-4" />
-                      <span>Log out</span>
+                      <span>{t('header.logout')}</span>
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
@@ -224,7 +224,7 @@ export function Header() {
                     <Button variant="outline" className="w-full" asChild>
                       <Link to="/account" onClick={() => setIsMenuOpen(false)}>
                         <User className="h-4 w-4 mr-2" />
-                        My Account
+                        {t('header.myAccount')}
                       </Link>
                     </Button>
                     <Button 
@@ -236,7 +236,7 @@ export function Header() {
                       }}
                     >
                       <LogOut className="h-4 w-4 mr-2" />
-                      Log out
+                      {t('header.logout')}
                     </Button>
                   </>
                 ) : (

--- a/client/contexts/LanguageContext.tsx
+++ b/client/contexts/LanguageContext.tsx
@@ -215,6 +215,659 @@ const translations: Translations = {
     it: 'Paga',
     es: 'Pagar',
     ru: 'Платить'
+  },
+
+  // Browse Page
+  'browse.searchPlaceholder': {
+    en: 'Search by storage type, location, or features...',
+    de: 'Suche nach Lagerart, Standort oder Merkmalen...',
+    it: 'Cerca per tipo di deposito, posizione o caratteristiche...',
+    es: 'Buscar por tipo de almacenamiento, ubicación o características...',
+    ru: 'Поиск по типу хранения, местоположению или характеристикам...'
+  },
+  'browse.startDate': {
+    en: 'Start Date',
+    de: 'Startdatum',
+    it: 'Data di inizio',
+    es: 'Fecha de inicio',
+    ru: 'Дата начала'
+  },
+  'browse.endDate': {
+    en: 'End Date',
+    de: 'Enddatum',
+    it: 'Data di fine',
+    es: 'Fecha de fin',
+    ru: 'Дата окончания'
+  },
+  'browse.search': {
+    en: 'Search',
+    de: 'Suchen',
+    it: 'Cerca',
+    es: 'Buscar',
+    ru: 'Поиск'
+  },
+  'browse.category': {
+    en: 'Category',
+    de: 'Kategorie',
+    it: 'Categoria',
+    es: 'Categoría',
+    ru: 'Категория'
+  },
+  'browse.allCategories': {
+    en: 'All Categories',
+    de: 'Alle Kategorien',
+    it: 'Tutte le categorie',
+    es: 'Todas las categorías',
+    ru: 'Все категории'
+  },
+  'browse.priceRange': {
+    en: 'Price Range',
+    de: 'Preisspanne',
+    it: 'Fascia di prezzo',
+    es: 'Rango de precios',
+    ru: 'Диапазон цен'
+  },
+  'browse.allPrices': {
+    en: 'All Prices',
+    de: 'Alle Preise',
+    it: 'Tutti i prezzi',
+    es: 'Todos los precios',
+    ru: 'Все цены'
+  },
+  'browse.under10': {
+    en: 'Under $10/day',
+    de: 'Unter 10 $/Tag',
+    it: 'Sotto 10 $/giorno',
+    es: 'Menos de $10/día',
+    ru: 'Меньше 10 $/день'
+  },
+  'browse.tenToTwenty': {
+    en: '$10-20/day',
+    de: '10–20 $/Tag',
+    it: '10-20 $/giorno',
+    es: '$10-20/día',
+    ru: '10–20 $/день'
+  },
+  'browse.twentyToFifty': {
+    en: '$20-50/day',
+    de: '20–50 $/Tag',
+    it: '20-50 $/giorno',
+    es: '$20-50/día',
+    ru: '20–50 $/день'
+  },
+  'browse.over50': {
+    en: 'Over $50/day',
+    de: 'Über 50 $/Tag',
+    it: 'Oltre 50 $/giorno',
+    es: 'Más de $50/día',
+    ru: 'Больше 50 $/день'
+  },
+  'browse.sortBy': {
+    en: 'Sort by',
+    de: 'Sortieren nach',
+    it: 'Ordina per',
+    es: 'Ordenar por',
+    ru: 'Сортировать по'
+  },
+  'browse.featured': {
+    en: 'Featured',
+    de: 'Empfohlen',
+    it: 'In evidenza',
+    es: 'Destacado',
+    ru: 'Избранное'
+  },
+  'browse.priceLowHigh': {
+    en: 'Price: Low to High',
+    de: 'Preis: aufsteigend',
+    it: "Prezzo: dal basso all'alto",
+    es: 'Precio: de menor a mayor',
+    ru: 'Цена: по возрастанию'
+  },
+  'browse.priceHighLow': {
+    en: 'Price: High to Low',
+    de: 'Preis: absteigend',
+    it: "Prezzo: dall'alto al basso",
+    es: 'Precio: de mayor a menor',
+    ru: 'Цена: по убыванию'
+  },
+  'browse.highestRated': {
+    en: 'Highest Rated',
+    de: 'Beste Bewertung',
+    it: 'Miglior valutato',
+    es: 'Mejor valorado',
+    ru: 'С наивысшей оценкой'
+  },
+  'browse.newestFirst': {
+    en: 'Newest First',
+    de: 'Neueste zuerst',
+    it: 'Più recenti',
+    es: 'Más recientes',
+    ru: 'Сначала новые'
+  },
+  'browse.moreFilters': {
+    en: 'More Filters',
+    de: 'Weitere Filter',
+    it: 'Altri filtri',
+    es: 'Más filtros',
+    ru: 'Больше фильтров'
+  },
+  'browse.listingType': {
+    en: 'Listing Type',
+    de: 'Angebotsart',
+    it: 'Tipo di annuncio',
+    es: 'Tipo de anuncio',
+    ru: 'Тип объявления'
+  },
+  'browse.forRent': {
+    en: 'For Rent',
+    de: 'Zur Miete',
+    it: 'In affitto',
+    es: 'En alquiler',
+    ru: 'В аренду'
+  },
+  'browse.forSale': {
+    en: 'For Sale',
+    de: 'Zum Verkauf',
+    it: 'In vendita',
+    es: 'En venta',
+    ru: 'Продается'
+  },
+  'browse.priceRangeLabel': {
+    en: 'Price Range',
+    de: 'Preisspanne',
+    it: 'Fascia di prezzo',
+    es: 'Rango de precios',
+    ru: 'Диапазон цен'
+  },
+  'browse.sizeRange': {
+    en: 'Size Range',
+    de: 'Größenbereich',
+    it: 'Intervallo di dimensioni',
+    es: 'Rango de tamaño',
+    ru: 'Диапазон размеров'
+  },
+  'browse.type': {
+    en: 'Type',
+    de: 'Typ',
+    it: 'Tipo',
+    es: 'Tipo',
+    ru: 'Тип'
+  },
+  'browse.allTypes': {
+    en: 'All Types',
+    de: 'Alle Typen',
+    it: 'Tutti i tipi',
+    es: 'Todos los tipos',
+    ru: 'Все типы'
+  },
+  'browse.hardside': {
+    en: 'Hardside',
+    de: 'Hartschale',
+    it: 'Rigido',
+    es: 'Rígido',
+    ru: 'Жёсткий'
+  },
+  'browse.softside': {
+    en: 'Softside',
+    de: 'Weichschale',
+    it: 'Morbido',
+    es: 'Blando',
+    ru: 'Мягкий'
+  },
+  'browse.hybrid': {
+    en: 'Hybrid',
+    de: 'Hybrid',
+    it: 'Ibrido',
+    es: 'Híbrido',
+    ru: 'Гибрид'
+  },
+  'browse.condition': {
+    en: 'Condition',
+    de: 'Zustand',
+    it: 'Condizione',
+    es: 'Condición',
+    ru: 'Состояние'
+  },
+  'browse.allConditions': {
+    en: 'All Conditions',
+    de: 'Alle Zustände',
+    it: 'Tutte le condizioni',
+    es: 'Todas las condiciones',
+    ru: 'Все состояния'
+  },
+  'browse.new': {
+    en: 'New',
+    de: 'Neu',
+    it: 'Nuovo',
+    es: 'Nuevo',
+    ru: 'Новый'
+  },
+  'browse.excellent': {
+    en: 'Excellent',
+    de: 'Ausgezeichnet',
+    it: 'Eccellente',
+    es: 'Excelente',
+    ru: 'Отличное'
+  },
+  'browse.good': {
+    en: 'Good',
+    de: 'Gut',
+    it: 'Buono',
+    es: 'Bueno',
+    ru: 'Хорошее'
+  },
+  'browse.fair': {
+    en: 'Fair',
+    de: 'Mittel',
+    it: 'Discreto',
+    es: 'Regular',
+    ru: 'Удовлетворительное'
+  },
+  'browse.minRentalDays': {
+    en: 'Min Rental Days',
+    de: 'Mindestmiettage',
+    it: 'Giorni minimi di noleggio',
+    es: 'Días mínimos de alquiler',
+    ru: 'Минимум дней аренды'
+  },
+  'browse.maxRentalDays': {
+    en: 'Max Rental Days',
+    de: 'Maximale Miettage',
+    it: 'Giorni massimi di noleggio',
+    es: 'Días máximos de alquiler',
+    ru: 'Максимум дней аренды'
+  },
+  'browse.securityDeposit': {
+    en: 'Security Deposit',
+    de: 'Kaution',
+    it: 'Deposito cauzionale',
+    es: 'Depósito de seguridad',
+    ru: 'Залог'
+  },
+  'browse.optionsAvailable': {
+    en: 'luggage options available',
+    de: 'Gepäckoptionen verfügbar',
+    it: 'opzioni di bagaglio disponibili',
+    es: 'opciones de equipaje disponibles',
+    ru: 'доступных вариантов багажа'
+  },
+  'browse.areaNotSpecified': {
+    en: 'Area not specified',
+    de: 'Fläche nicht angegeben',
+    it: 'Area non specificata',
+    es: 'Área no especificada',
+    ru: 'Площадь не указана'
+  },
+  'browse.noResults': {
+    en: 'No listings found',
+    de: 'Keine Einträge gefunden',
+    it: 'Nessun annuncio trovato',
+    es: 'No se encontraron anuncios',
+    ru: 'Объявления не найдены'
+  },
+  'browse.adjustSearch': {
+    en: 'Try adjusting your search criteria or check back later for new listings.',
+    de: 'Versuchen Sie, Ihre Suchkriterien anzupassen, oder schauen Sie später erneut nach neuen Angeboten.',
+    it: 'Prova a modificare i criteri di ricerca o torna più tardi per nuovi annunci.',
+    es: 'Intenta ajustar tus criterios de búsqueda o vuelve más tarde para ver nuevos anuncios.',
+    ru: 'Попробуйте изменить критерии поиска или зайдите позже, чтобы увидеть новые объявления.'
+  },
+  'browse.clearFilters': {
+    en: 'Clear Filters',
+    de: 'Filter löschen',
+    it: 'Pulisci filtri',
+    es: 'Borrar filtros',
+    ru: 'Сбросить фильтры'
+  },
+
+  'browse.perDay': {
+    en: 'per day',
+    de: 'pro Tag',
+    it: 'al giorno',
+    es: 'por día',
+    ru: 'в день'
+  },
+
+  // Listing categories
+  'luggageCategory.carry-on': {
+    en: 'Carry-on',
+    de: 'Handgepäck',
+    it: 'Bagaglio a mano',
+    es: 'Equipaje de mano',
+    ru: 'Ручная кладь'
+  },
+  'luggageCategory.medium': {
+    en: 'Medium',
+    de: 'Mittel',
+    it: 'Medio',
+    es: 'Mediano',
+    ru: 'Средний'
+  },
+  'luggageCategory.large': {
+    en: 'Large',
+    de: 'Groß',
+    it: 'Grande',
+    es: 'Grande',
+    ru: 'Большой'
+  },
+  'luggageCategory.extra-large': {
+    en: 'Extra Large',
+    de: 'Extra groß',
+    it: 'Extra grande',
+    es: 'Extra grande',
+    ru: 'Очень большой'
+  },
+  'luggageCategory.backpack': {
+    en: 'Backpack',
+    de: 'Rucksack',
+    it: 'Zaino',
+    es: 'Mochila',
+    ru: 'Рюкзак'
+  },
+  'luggageCategory.duffel': {
+    en: 'Duffel',
+    de: 'Reisetasche',
+    it: 'Borsone',
+    es: 'Bolsa de viaje',
+    ru: 'Дорожная сумка'
+  },
+  'luggageCategory.other': {
+    en: 'Other',
+    de: 'Andere',
+    it: 'Altro',
+    es: 'Otro',
+    ru: 'Другое'
+  },
+
+  // Header additions
+  'header.account': {
+    en: 'Account',
+    de: 'Konto',
+    it: 'Account',
+    es: 'Cuenta',
+    ru: 'Аккаунт'
+  },
+  'header.myBookings': {
+    en: 'My Bookings',
+    de: 'Meine Buchungen',
+    it: 'Le mie prenotazioni',
+    es: 'Mis reservas',
+    ru: 'Мои бронирования'
+  },
+  'header.settings': {
+    en: 'Settings',
+    de: 'Einstellungen',
+    it: 'Impostazioni',
+    es: 'Configuración',
+    ru: 'Настройки'
+  },
+  'header.logout': {
+    en: 'Log out',
+    de: 'Abmelden',
+    it: 'Esci',
+    es: 'Cerrar sesión',
+    ru: 'Выйти'
+  },
+  'header.myAccount': {
+    en: 'My Account',
+    de: 'Mein Konto',
+    it: 'Il mio account',
+    es: 'Mi cuenta',
+    ru: 'Мой аккаунт'
+  },
+
+  // Account Page
+  'account.memberSince': {
+    en: 'Member since',
+    de: 'Mitglied seit',
+    it: 'Membro dal',
+    es: 'Miembro desde',
+    ru: 'Участник с'
+  },
+  'account.host': {
+    en: 'Host',
+    de: 'Gastgeber',
+    it: 'Host',
+    es: 'Anfitrión',
+    ru: 'Хост'
+  },
+  'account.traveler': {
+    en: 'Traveler',
+    de: 'Reisender',
+    it: 'Viaggiatore',
+    es: 'Viajero',
+    ru: 'Путешественник'
+  },
+  'account.myBookingsTab': {
+    en: 'My Bookings',
+    de: 'Meine Buchungen',
+    it: 'Le mie prenotazioni',
+    es: 'Mis reservas',
+    ru: 'Мои бронирования'
+  },
+  'account.myListingsTab': {
+    en: 'My Listings',
+    de: 'Meine Angebote',
+    it: 'I miei annunci',
+    es: 'Mis anuncios',
+    ru: 'Мои объявления'
+  },
+  'account.profileTab': {
+    en: 'Profile',
+    de: 'Profil',
+    it: 'Profilo',
+    es: 'Perfil',
+    ru: 'Профиль'
+  },
+  'account.settingsTab': {
+    en: 'Settings',
+    de: 'Einstellungen',
+    it: 'Impostazioni',
+    es: 'Configuración',
+    ru: 'Настройки'
+  },
+  'account.totalBookings': {
+    en: 'Total Bookings',
+    de: 'Gesamtbuchungen',
+    it: 'Prenotazioni totali',
+    es: 'Reservas totales',
+    ru: 'Всего бронирований'
+  },
+  'account.nextTrip': {
+    en: 'Next Trip',
+    de: 'Nächste Reise',
+    it: 'Prossimo viaggio',
+    es: 'Próximo viaje',
+    ru: 'Следующая поездка'
+  },
+  'account.recentBookings': {
+    en: 'Recent Bookings',
+    de: 'Letzte Buchungen',
+    it: 'Prenotazioni recenti',
+    es: 'Reservas recientes',
+    ru: 'Недавние бронирования'
+  },
+  'account.activeListings': {
+    en: 'Active Listings',
+    de: 'Aktive Angebote',
+    it: 'Annunci attivi',
+    es: 'Anuncios activos',
+    ru: 'Активные объявления'
+  },
+  'account.allListingsActive': {
+    en: 'All listings active',
+    de: 'Alle Angebote aktiv',
+    it: 'Tutti gli annunci attivi',
+    es: 'Todos los anuncios activos',
+    ru: 'Все объявления активны'
+  },
+  'account.monthlyEarnings': {
+    en: 'Monthly Earnings',
+    de: 'Monatliche Einnahmen',
+    it: 'Guadagni mensili',
+    es: 'Ganancias mensuales',
+    ru: 'Ежемесячный доход'
+  },
+  'account.totalEarned': {
+    en: 'Total Earned',
+    de: 'Gesamtverdienst',
+    it: 'Guadagno totale',
+    es: 'Total ganado',
+    ru: 'Всего заработано'
+  },
+  'account.withdraw': {
+    en: 'Withdraw',
+    de: 'Auszahlen',
+    it: 'Preleva',
+    es: 'Retirar',
+    ru: 'Вывести'
+  },
+  'account.earningsOverview': {
+    en: 'Earnings Overview',
+    de: 'Übersicht der Einnahmen',
+    it: 'Panoramica guadagni',
+    es: 'Resumen de ganancias',
+    ru: 'Обзор доходов'
+  },
+  'account.yourListings': {
+    en: 'Your Listings',
+    de: 'Deine Angebote',
+    it: 'I tuoi annunci',
+    es: 'Tus anuncios',
+    ru: 'Ваши объявления'
+  },
+  'account.noListingsYet': {
+    en: 'No Listings Yet',
+    de: 'Noch keine Angebote',
+    it: 'Ancora nessun annuncio',
+    es: 'Aún no hay anuncios',
+    ru: 'Пока нет объявлений'
+  },
+  'account.startEarning': {
+    en: 'Start earning money by listing your storage space for rent.',
+    de: 'Beginne Geld zu verdienen, indem du deinen Stauraum zur Miete anbietest.',
+    it: 'Inizia a guadagnare mettendo in affitto il tuo spazio di deposito.',
+    es: 'Comienza a ganar dinero ofreciendo tu espacio de almacenamiento en alquiler.',
+    ru: 'Начните зарабатывать, сдавая свое место для хранения.'
+  },
+  'account.createFirstListing': {
+    en: 'Create Your First Listing',
+    de: 'Erstelle dein erstes Angebot',
+    it: 'Crea il tuo primo annuncio',
+    es: 'Crea tu primer anuncio',
+    ru: 'Создать первое объявление'
+  },
+  'account.personalInformation': {
+    en: 'Personal Information',
+    de: 'Persönliche Informationen',
+    it: 'Informazioni personali',
+    es: 'Información personal',
+    ru: 'Личная информация'
+  },
+  'account.firstName': {
+    en: 'First Name',
+    de: 'Vorname',
+    it: 'Nome',
+    es: 'Nombre',
+    ru: 'Имя'
+  },
+  'account.lastName': {
+    en: 'Last Name',
+    de: 'Nachname',
+    it: 'Cognome',
+    es: 'Apellido',
+    ru: 'Фамилия'
+  },
+  'account.email': {
+    en: 'Email',
+    de: 'E-Mail',
+    it: 'Email',
+    es: 'Correo electrónico',
+    ru: 'Электронная почта'
+  },
+  'account.mobileNumber': {
+    en: 'Mobile Number',
+    de: 'Handynummer',
+    it: 'Numero di cellulare',
+    es: 'Número de móvil',
+    ru: 'Номер телефона'
+  },
+  'account.editProfile': {
+    en: 'Edit Profile',
+    de: 'Profil bearbeiten',
+    it: 'Modifica profilo',
+    es: 'Editar perfil',
+    ru: 'Редактировать профиль'
+  },
+  'account.accountSettings': {
+    en: 'Account Settings',
+    de: 'Kontoeinstellungen',
+    it: 'Impostazioni account',
+    es: 'Configuración de la cuenta',
+    ru: 'Настройки аккаунта'
+  },
+  'account.emailNotifications': {
+    en: 'Email Notifications',
+    de: 'E-Mail-Benachrichtigungen',
+    it: 'Notifiche email',
+    es: 'Notificaciones por correo',
+    ru: 'Уведомления по email'
+  },
+  'account.receiveUpdates': {
+    en: 'Receive booking confirmations and updates',
+    de: 'Erhalte Buchungsbestätigungen und Updates',
+    it: 'Ricevi conferme e aggiornamenti delle prenotazioni',
+    es: 'Recibe confirmaciones y actualizaciones de reservas',
+    ru: 'Получайте подтверждения и обновления бронирований'
+  },
+  'account.manage': {
+    en: 'Manage',
+    de: 'Verwalten',
+    it: 'Gestisci',
+    es: 'Administrar',
+    ru: 'Управлять'
+  },
+  'account.privacySettings': {
+    en: 'Privacy Settings',
+    de: 'Datenschutzeinstellungen',
+    it: 'Impostazioni privacy',
+    es: 'Configuración de privacidad',
+    ru: 'Настройки конфиденциальности'
+  },
+  'account.controlProfile': {
+    en: 'Control who can see your profile',
+    de: 'Bestimme, wer dein Profil sehen kann',
+    it: 'Controlla chi può vedere il tuo profilo',
+    es: 'Controla quién puede ver tu perfil',
+    ru: 'Контролируйте, кто может видеть ваш профиль'
+  },
+  'account.configure': {
+    en: 'Configure',
+    de: 'Konfigurieren',
+    it: 'Configura',
+    es: 'Configurar',
+    ru: 'Настроить'
+  },
+  'account.paymentMethods': {
+    en: 'Payment Methods',
+    de: 'Zahlungsmethoden',
+    it: 'Metodi di pagamento',
+    es: 'Métodos de pago',
+    ru: 'Способы оплаты'
+  },
+  'account.managePayments': {
+    en: 'Manage your payment options',
+    de: 'Verwalte deine Zahlungsoptionen',
+    it: 'Gestisci le tue opzioni di pagamento',
+    es: 'Administra tus opciones de pago',
+    ru: 'Управляйте вариантами оплаты'
+  },
+  'account.signOut': {
+    en: 'Sign Out',
+    de: 'Abmelden',
+    it: 'Esci',
+    es: 'Cerrar sesión',
+    ru: 'Выйти'
   }
 };
 

--- a/client/pages/Account.tsx
+++ b/client/pages/Account.tsx
@@ -22,10 +22,12 @@ import {
   Shield,
   DollarSign,
 } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
 
 export default function Account() {
   const { user, isAuthenticated, logout } = useAuth();
   const { listings, userListings, updateListing } = useListings();
+  const { t } = useLanguage();
   const [editProfileOpen, setEditProfileOpen] = useState(false);
   const [managementModalOpen, setManagementModalOpen] = useState(false);
   const [selectedListing, setSelectedListing] = useState<any>(null);
@@ -110,7 +112,7 @@ export default function Account() {
                 {user.firstName} {user.lastName}
               </h1>
               <p className="text-white/80 mb-2">
-                Member since {new Date(user.joinDate).getFullYear()}
+                {t('account.memberSince')} {new Date(user.joinDate).getFullYear()}
               </p>
               <div className="flex items-center gap-4">
                 <div className="flex items-center gap-1">
@@ -118,7 +120,7 @@ export default function Account() {
                   <span>4.9 rating</span>
                 </div>
                 <Badge variant="secondary" className="bg-white/20 text-white">
-                  {user.isHost ? "Host" : "Traveler"}
+                  {user.isHost ? t('account.host') : t('account.traveler')}
                 </Badge>
               </div>
             </div>
@@ -127,10 +129,10 @@ export default function Account() {
 
         <Tabs defaultValue="bookings" className="space-y-6">
           <TabsList className="grid w-full grid-cols-4">
-            <TabsTrigger value="bookings">My Bookings</TabsTrigger>
-            <TabsTrigger value="listings">My Listings</TabsTrigger>
-            <TabsTrigger value="profile">Profile</TabsTrigger>
-            <TabsTrigger value="settings">Settings</TabsTrigger>
+            <TabsTrigger value="bookings">{t('account.myBookingsTab')}</TabsTrigger>
+            <TabsTrigger value="listings">{t('account.myListingsTab')}</TabsTrigger>
+            <TabsTrigger value="profile">{t('account.profileTab')}</TabsTrigger>
+            <TabsTrigger value="settings">{t('account.settingsTab')}</TabsTrigger>
           </TabsList>
 
           <TabsContent value="bookings" className="space-y-6">
@@ -138,7 +140,7 @@ export default function Account() {
               <Card>
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                   <CardTitle className="text-sm font-medium">
-                    Total Bookings
+                    {t('account.totalBookings')}
                   </CardTitle>
                   <Calendar className="h-4 w-4 text-muted-foreground" />
                 </CardHeader>
@@ -153,7 +155,7 @@ export default function Account() {
               <Card>
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                   <CardTitle className="text-sm font-medium">
-                    Next Trip
+                    {t('account.nextTrip')}
                   </CardTitle>
                   <MapPin className="h-4 w-4 text-muted-foreground" />
                 </CardHeader>
@@ -167,7 +169,7 @@ export default function Account() {
             </div>
 
             <div className="space-y-4">
-              <h3 className="text-lg font-semibold">Recent Bookings</h3>
+              <h3 className="text-lg font-semibold">{t('account.recentBookings')}</h3>
               {mockBookings.map((booking) => (
                 <Card key={booking.id}>
                   <CardContent className="p-6">
@@ -217,7 +219,7 @@ export default function Account() {
                   <Card>
                     <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                       <CardTitle className="text-sm font-medium">
-                        Active Listings
+                        {t('account.activeListings')}
                       </CardTitle>
                       <Package className="h-4 w-4 text-muted-foreground" />
                     </CardHeader>
@@ -226,7 +228,7 @@ export default function Account() {
                          {localListings.length}
                        </div>
                       <p className="text-xs text-muted-foreground">
-                        All listings active
+                        {t('account.allListingsActive')}
                       </p>
                     </CardContent>
                   </Card>
@@ -234,7 +236,7 @@ export default function Account() {
                   <Card>
                     <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                       <CardTitle className="text-sm font-medium">
-                        Monthly Earnings
+                        {t('account.monthlyEarnings')}
                       </CardTitle>
                       <TrendingUp className="h-4 w-4 text-muted-foreground" />
                     </CardHeader>
@@ -251,14 +253,14 @@ export default function Account() {
                   <Card>
                     <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                       <CardTitle className="text-sm font-medium">
-                        Total Earned
+                        {t('account.totalEarned')}
                       </CardTitle>
                       <DollarSign className="h-4 w-4 text-muted-foreground" />
                     </CardHeader>
                     <CardContent>
                       <div className="text-2xl font-bold">${totalEarnings}</div>
                       <Button variant="outline" size="sm" className="mt-2">
-                        Withdraw
+                        {t('account.withdraw')}
                       </Button>
                     </CardContent>
                   </Card>
@@ -267,7 +269,7 @@ export default function Account() {
                 {/* Earnings Graph */}
                 <Card>
                   <CardHeader>
-                    <CardTitle>Earnings Overview</CardTitle>
+                    <CardTitle>{t('account.earningsOverview')}</CardTitle>
                   </CardHeader>
                   <CardContent>
                     <div className="h-64 flex items-end justify-between gap-2">
@@ -297,7 +299,7 @@ export default function Account() {
 
                 {/* User's Listings */}
                 <div className="space-y-4">
-                  <h3 className="text-lg font-semibold">Your Listings</h3>
+                  <h3 className="text-lg font-semibold">{t('account.yourListings')}</h3>
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                     {localListings.map((listing) => (
                       <Card 
@@ -336,14 +338,14 @@ export default function Account() {
                           </p>
                           <div className="flex items-center justify-between mt-3">
                             <Badge variant="outline" className="text-xs">
-                              {listing.condition}
+                              {t(`browse.${listing.condition}`)}
                             </Badge>
                             <div className="flex items-center">
                               <Star className="h-3 w-3 fill-yellow-400 text-yellow-400 mr-1" />
                               <span className="text-xs">
                                 {listing.rating > 0
                                   ? listing.rating.toFixed(1)
-                                  : "New"}
+                                  : t('browse.new')}
                               </span>
                             </div>
                           </div>
@@ -358,13 +360,13 @@ export default function Account() {
                 <CardContent className="p-12 text-center">
                   <Package className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
                   <h3 className="text-lg font-semibold mb-2">
-                    No Listings Yet
+                    {t('account.noListingsYet')}
                   </h3>
                   <p className="text-muted-foreground mb-6">
-                    Start earning money by listing your storage space for rent.
+                    {t('account.startEarning')}
                   </p>
                   <Button asChild>
-                    <Link to="/host">Create Your First Listing</Link>
+                    <Link to="/host">{t('account.createFirstListing')}</Link>
                   </Button>
                 </CardContent>
               </Card>
@@ -376,32 +378,32 @@ export default function Account() {
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <User className="h-5 w-5" />
-                  Personal Information
+                  {t('account.personalInformation')}
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <label className="text-sm font-medium">First Name</label>
+                    <label className="text-sm font-medium">{t('account.firstName')}</label>
                     <p className="text-muted-foreground">{user.firstName}</p>
                   </div>
                   <div>
-                    <label className="text-sm font-medium">Last Name</label>
+                    <label className="text-sm font-medium">{t('account.lastName')}</label>
                     <p className="text-muted-foreground">{user.lastName}</p>
                   </div>
                 </div>
                 <div>
-                  <label className="text-sm font-medium">Email</label>
+                  <label className="text-sm font-medium">{t('account.email')}</label>
                   <p className="text-muted-foreground">{user.email}</p>
                 </div>
                 <div>
-                  <label className="text-sm font-medium">Mobile Number</label>
+                  <label className="text-sm font-medium">{t('account.mobileNumber')}</label>
                   <p className="text-muted-foreground">
                     {user.phoneNumber || "Not provided"}
                   </p>
                 </div>
                 <div>
-                  <label className="text-sm font-medium">Member Since</label>
+                  <label className="text-sm font-medium">{t('account.memberSince')}</label>
                   <p className="text-muted-foreground">
                     {new Date(user.joinDate).toLocaleDateString()}
                   </p>
@@ -411,7 +413,7 @@ export default function Account() {
                   className="mt-4"
                   onClick={() => setEditProfileOpen(true)}
                 >
-                  Edit Profile
+                  {t('account.editProfile')}
                 </Button>
               </CardContent>
             </Card>
@@ -422,50 +424,50 @@ export default function Account() {
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <Settings className="h-5 w-5" />
-                  Account Settings
+                  {t('account.accountSettings')}
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-6">
                 <div className="flex items-center justify-between">
                   <div>
-                    <h4 className="font-medium">Email Notifications</h4>
+                    <h4 className="font-medium">{t('account.emailNotifications')}</h4>
                     <p className="text-sm text-muted-foreground">
-                      Receive booking confirmations and updates
+                      {t('account.receiveUpdates')}
                     </p>
                   </div>
                   <Button variant="outline" size="sm">
-                    Manage
+                    {t('account.manage')}
                   </Button>
                 </div>
 
                 <div className="flex items-center justify-between">
                   <div>
-                    <h4 className="font-medium">Privacy Settings</h4>
+                    <h4 className="font-medium">{t('account.privacySettings')}</h4>
                     <p className="text-sm text-muted-foreground">
-                      Control who can see your profile
+                      {t('account.controlProfile')}
                     </p>
                   </div>
                   <Button variant="outline" size="sm">
-                    Configure
+                    {t('account.configure')}
                   </Button>
                 </div>
 
                 <div className="flex items-center justify-between">
                   <div>
-                    <h4 className="font-medium">Payment Methods</h4>
+                    <h4 className="font-medium">{t('account.paymentMethods')}</h4>
                     <p className="text-sm text-muted-foreground">
-                      Manage your payment options
+                      {t('account.managePayments')}
                     </p>
                   </div>
                   <Button variant="outline" size="sm">
                     <CreditCard className="h-4 w-4 mr-2" />
-                    Manage
+                    {t('account.manage')}
                   </Button>
                 </div>
 
                 <div className="pt-6 border-t">
                   <Button variant="destructive" onClick={logout}>
-                    Sign Out
+                    {t('account.signOut')}
                   </Button>
                 </div>
               </CardContent>

--- a/client/pages/Browse.tsx
+++ b/client/pages/Browse.tsx
@@ -28,9 +28,11 @@ import {
 } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
 
 export default function Browse() {
   const { listings, searchListings } = useListings();
+  const { t } = useLanguage();
   
   // Debug: Log listings count
   useEffect(() => {
@@ -204,7 +206,7 @@ export default function Browse() {
       {/* Search Header */}
       <div className="bg-white border-b">
         <div className="container py-6">
-          <h1 className="text-3xl font-bold mb-6">Browse Luggage</h1>
+          <h1 className="text-3xl font-bold mb-6">{t('header.browseLuggage')}</h1>
 
           {/* Search Bar */}
           <div className="space-y-6">
@@ -212,7 +214,7 @@ export default function Browse() {
               <div className="flex-1 relative">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
                 <Input
-                  placeholder="Search by storage type, location, or features..."
+                  placeholder={t('browse.searchPlaceholder')}
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   className="pl-10"
@@ -221,7 +223,7 @@ export default function Browse() {
               <div className="flex gap-4 items-end">
                 <div className="space-y-2">
                   <label className="text-sm font-medium text-gray-700">
-                    Start Date
+                    {t('browse.startDate')}
                   </label>
                   <Input
                     type="date"
@@ -232,7 +234,7 @@ export default function Browse() {
                 </div>
                 <div className="space-y-2">
                   <label className="text-sm font-medium text-gray-700">
-                    End Date
+                    {t('browse.endDate')}
                   </label>
                   <Input
                     type="date"
@@ -243,7 +245,7 @@ export default function Browse() {
                 </div>
                 <Button onClick={handleSearch} className="h-10 bg-primary hover:bg-primary/90">
                   <Search className="h-4 w-4 mr-2" />
-                  Search
+                  {t('browse.search')}
                 </Button>
               </div>
             </div>
@@ -256,51 +258,51 @@ export default function Browse() {
               onValueChange={setSelectedCategory}
             >
               <SelectTrigger className="w-48">
-                <SelectValue placeholder="Category" />
+                <SelectValue placeholder={t('browse.category')} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All Categories</SelectItem>
-                <SelectItem value="garage">Garage</SelectItem>
-                <SelectItem value="shed">Shed</SelectItem>
-                <SelectItem value="pantry">Pantry</SelectItem>
-                <SelectItem value="cell">Storage Cell</SelectItem>
-                <SelectItem value="container">Container</SelectItem>
-                <SelectItem value="large-space">Large Space</SelectItem>
+                <SelectItem value="all">{t('browse.allCategories')}</SelectItem>
+                <SelectItem value="garage">{t('category.garage')}</SelectItem>
+                <SelectItem value="shed">{t('category.shed')}</SelectItem>
+                <SelectItem value="pantry">{t('category.pantry')}</SelectItem>
+                <SelectItem value="cell">{t('category.cell')}</SelectItem>
+                <SelectItem value="container">{t('category.container')}</SelectItem>
+                <SelectItem value="large-space">{t('category.largeSpace')}</SelectItem>
               </SelectContent>
             </Select>
 
             <Select value={priceRange} onValueChange={setPriceRange}>
               <SelectTrigger className="w-48">
-                <SelectValue placeholder="Price Range" />
+                <SelectValue placeholder={t('browse.priceRange')} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All Prices</SelectItem>
-                <SelectItem value="under-10">Under $10/day</SelectItem>
-                <SelectItem value="10-20">$10-20/day</SelectItem>
-                <SelectItem value="20-50">$20-50/day</SelectItem>
-                <SelectItem value="over-50">Over $50/day</SelectItem>
+                <SelectItem value="all">{t('browse.allPrices')}</SelectItem>
+                <SelectItem value="under-10">{t('browse.under10')}</SelectItem>
+                <SelectItem value="10-20">{t('browse.tenToTwenty')}</SelectItem>
+                <SelectItem value="20-50">{t('browse.twentyToFifty')}</SelectItem>
+                <SelectItem value="over-50">{t('browse.over50')}</SelectItem>
               </SelectContent>
             </Select>
 
             <Select value={sortBy} onValueChange={setSortBy}>
               <SelectTrigger className="w-48">
-                <SelectValue placeholder="Sort by" />
+                <SelectValue placeholder={t('browse.sortBy')} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="featured">Featured</SelectItem>
-                <SelectItem value="price-low">Price: Low to High</SelectItem>
-                <SelectItem value="price-high">Price: High to Low</SelectItem>
-                <SelectItem value="rating">Highest Rated</SelectItem>
-                <SelectItem value="newest">Newest First</SelectItem>
+                <SelectItem value="featured">{t('browse.featured')}</SelectItem>
+                <SelectItem value="price-low">{t('browse.priceLowHigh')}</SelectItem>
+                <SelectItem value="price-high">{t('browse.priceHighLow')}</SelectItem>
+                <SelectItem value="rating">{t('browse.highestRated')}</SelectItem>
+                <SelectItem value="newest">{t('browse.newestFirst')}</SelectItem>
               </SelectContent>
             </Select>
 
-            <Button 
+            <Button
               variant="outline"
               onClick={() => setShowAdvancedFilters(!showAdvancedFilters)}
             >
               <SlidersHorizontal className="h-4 w-4 mr-2" />
-              More Filters
+              {t('browse.moreFilters')}
             </Button>
           </div>
 
@@ -308,7 +310,7 @@ export default function Browse() {
           <div className="mt-4 pt-4 border-t">
             <div className="flex items-center justify-between">
               <div className="space-y-2">
-                <Label className="text-sm font-medium text-gray-700">Listing Type</Label>
+                <Label className="text-sm font-medium text-gray-700">{t('browse.listingType')}</Label>
                 <div className="flex items-center space-x-6">
                   <div className="flex items-center space-x-2">
                     <Switch
@@ -316,7 +318,7 @@ export default function Browse() {
                       checked={selectedListingType === "rent"}
                       onCheckedChange={(checked) => setSelectedListingType(checked ? "rent" : "sale")}
                     />
-                    <Label htmlFor="browse-rent" className="text-sm">For Rent</Label>
+                    <Label htmlFor="browse-rent" className="text-sm">{t('browse.forRent')}</Label>
                   </div>
                   <div className="flex items-center space-x-2">
                     <Switch
@@ -324,7 +326,7 @@ export default function Browse() {
                       checked={selectedListingType === "sale"}
                       onCheckedChange={(checked) => setSelectedListingType(checked ? "sale" : "rent")}
                     />
-                    <Label htmlFor="browse-sale" className="text-sm">For Sale</Label>
+                    <Label htmlFor="browse-sale" className="text-sm">{t('browse.forSale')}</Label>
                   </div>
                 </div>
               </div>
@@ -335,8 +337,7 @@ export default function Browse() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6 pt-6 border-t">
             <div className="space-y-3">
               <label className="text-sm font-medium">
-                Price Range: ${priceRangeSlider[0]} - ${priceRangeSlider[1]} per
-                day
+                {t('browse.priceRangeLabel')}: ${priceRangeSlider[0]} - ${priceRangeSlider[1]} {t('browse.perDay')}
               </label>
               <Slider
                 value={priceRangeSlider}
@@ -349,7 +350,7 @@ export default function Browse() {
             </div>
             <div className="space-y-3">
               <label className="text-sm font-medium">
-                Size Range: {sizeRangeSlider[0]} - {sizeRangeSlider[1]} m²
+                {t('browse.sizeRange')}: {sizeRangeSlider[0]} - {sizeRangeSlider[1]} m²
               </label>
               <Slider
                 value={sizeRangeSlider}
@@ -367,46 +368,46 @@ export default function Browse() {
             <div className="mt-6 pt-6 border-t space-y-6">
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div className="space-y-2">
-                  <label className="text-sm font-medium">Type</label>
+                  <label className="text-sm font-medium">{t('browse.type')}</label>
                   <Select value={selectedType} onValueChange={setSelectedType}>
                     <SelectTrigger>
-                      <SelectValue placeholder="All Types" />
+                      <SelectValue placeholder={t('browse.allTypes')} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="all">All Types</SelectItem>
-                      <SelectItem value="hardside">Hardside</SelectItem>
-                      <SelectItem value="softside">Softside</SelectItem>
-                      <SelectItem value="hybrid">Hybrid</SelectItem>
+                      <SelectItem value="all">{t('browse.allTypes')}</SelectItem>
+                      <SelectItem value="hardside">{t('browse.hardside')}</SelectItem>
+                      <SelectItem value="softside">{t('browse.softside')}</SelectItem>
+                      <SelectItem value="hybrid">{t('browse.hybrid')}</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
 
                 <div className="space-y-2">
-                  <label className="text-sm font-medium">Condition</label>
+                  <label className="text-sm font-medium">{t('browse.condition')}</label>
                   <Select value={selectedCondition} onValueChange={setSelectedCondition}>
                     <SelectTrigger>
-                      <SelectValue placeholder="All Conditions" />
+                      <SelectValue placeholder={t('browse.allConditions')} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="all">All Conditions</SelectItem>
-                      <SelectItem value="new">New</SelectItem>
-                      <SelectItem value="excellent">Excellent</SelectItem>
-                      <SelectItem value="good">Good</SelectItem>
-                      <SelectItem value="fair">Fair</SelectItem>
+                      <SelectItem value="all">{t('browse.allConditions')}</SelectItem>
+                      <SelectItem value="new">{t('browse.new')}</SelectItem>
+                      <SelectItem value="excellent">{t('browse.excellent')}</SelectItem>
+                      <SelectItem value="good">{t('browse.good')}</SelectItem>
+                      <SelectItem value="fair">{t('browse.fair')}</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
 
                 <div className="space-y-2">
-                  <label className="text-sm font-medium">Listing Type</label>
+                  <label className="text-sm font-medium">{t('browse.listingType')}</label>
                   <Select value={selectedListingType} onValueChange={setSelectedListingType}>
                     <SelectTrigger>
-                      <SelectValue placeholder="All Types" />
+                      <SelectValue placeholder={t('browse.allTypes')} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="all">All Types</SelectItem>
-                      <SelectItem value="rent">For Rent</SelectItem>
-                      <SelectItem value="sale">For Sale</SelectItem>
+                      <SelectItem value="all">{t('browse.allTypes')}</SelectItem>
+                      <SelectItem value="rent">{t('browse.forRent')}</SelectItem>
+                      <SelectItem value="sale">{t('browse.forSale')}</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
@@ -414,7 +415,7 @@ export default function Browse() {
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <label className="text-sm font-medium">Min Rental Days</label>
+                  <label className="text-sm font-medium">{t('browse.minRentalDays')}</label>
                   <Input
                     type="number"
                     placeholder="1"
@@ -423,7 +424,7 @@ export default function Browse() {
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-sm font-medium">Max Rental Days</label>
+                  <label className="text-sm font-medium">{t('browse.maxRentalDays')}</label>
                   <Input
                     type="number"
                     placeholder="30"
@@ -435,7 +436,7 @@ export default function Browse() {
 
               <div className="space-y-3">
                 <label className="text-sm font-medium">
-                  Security Deposit: ${securityDepositRange[0]} - ${securityDepositRange[1]}
+                  {t('browse.securityDeposit')}: ${securityDepositRange[0]} - ${securityDepositRange[1]}
                 </label>
                 <Slider
                   value={securityDepositRange}
@@ -455,7 +456,7 @@ export default function Browse() {
       <div className="container py-8">
         <div className="flex justify-between items-center mb-6">
           <p className="text-muted-foreground">
-            {sortedListings.length} luggage options available
+            {sortedListings.length} {t('browse.optionsAvailable')}
           </p>
         </div>
 
@@ -485,7 +486,7 @@ export default function Browse() {
                         variant="outline"
                         className="bg-white/90 text-green-700 border-green-300"
                       >
-                        For Sale: ${listing.pricing.sellPrice}
+                        {t('browse.forSale')}: ${listing.pricing.sellPrice}
                       </Badge>
                     )}
                   </div>
@@ -494,7 +495,7 @@ export default function Browse() {
                       variant="outline"
                       className="bg-white/90 text-gray-800 capitalize"
                     >
-                      {listing.category.replace("-", " ")}
+                      {t(`luggageCategory.${listing.category}`)}
                     </Badge>
                   </div>
                 </div>
@@ -537,7 +538,7 @@ export default function Browse() {
                         <span className="text-sm font-medium">
                           {listing.rating > 0
                             ? listing.rating.toFixed(1)
-                            : "New"}
+                            : t('browse.new')}
                         </span>
                         {listing.reviewCount > 0 && (
                           <span className="text-sm text-muted-foreground">
@@ -551,7 +552,7 @@ export default function Browse() {
                         }
                         className="text-xs"
                       >
-                        {listing.condition}
+                        {t(`browse.${listing.condition}`)}
                       </Badge>
                     </div>
 
@@ -565,10 +566,10 @@ export default function Browse() {
                                                  <div className="text-sm text-muted-foreground">
                            {listing.area && !isNaN(listing.area)
                              ? `${listing.area} m²`
-                             : 'Area not specified'
+                             : t('browse.areaNotSpecified')
                            }
-                         </div>
                       </div>
+                    </div>
                     </div>
 
                     <div className="flex gap-2">
@@ -582,7 +583,7 @@ export default function Browse() {
                           }}
                         >
                           <Calendar className="h-3 w-3 mr-1" />
-                          Book
+                          {t('common.book')}
                         </Button>
                       )}
                       {listing.pricing.isForSale && (
@@ -596,7 +597,7 @@ export default function Browse() {
                           }}
                         >
                           <Users className="h-3 w-3 mr-1" />
-                          Contact
+                          {t('common.contact')}
                         </Button>
                       )}
                     </div>
@@ -608,12 +609,11 @@ export default function Browse() {
         ) : (
           <div className="text-center py-12">
             <Package className="h-16 w-16 text-muted-foreground mx-auto mb-4" />
-            <h3 className="text-xl font-semibold mb-2">No listings found</h3>
+            <h3 className="text-xl font-semibold mb-2">{t('browse.noResults')}</h3>
             <p className="text-muted-foreground mb-6">
-              Try adjusting your search criteria or check back later for new
-              listings.
+              {t('browse.adjustSearch')}
             </p>
-            <Button variant="outline">Clear Filters</Button>
+            <Button variant="outline">{t('browse.clearFilters')}</Button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add translation keys for browse filters, listing categories, header and account screens
- replace hardcoded strings in Browse, Header and Account with language helper

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898f3b5f070832eb4b6c3d0966411c6