### PR TITLE
feat: use real listing fields

### DIFF
--- a/client/pages/Browse.tsx
+++ b/client/pages/Browse.tsx
@@ -104,7 +104,10 @@ export default function Browse() {
     if (
       searchTerm &&
       !listing.title.toLowerCase().includes(searchTerm.toLowerCase()) &&
-      !listing.location.city.toLowerCase().includes(searchTerm.toLowerCase())
+      !listing.location.city.toLowerCase().includes(searchTerm.toLowerCase()) &&
+      !listing.features.some((feature) =>
+        feature.toLowerCase().includes(searchTerm.toLowerCase()),
+      )
     )
       return false;
 


### PR DESCRIPTION
## Summary
- map category, type, features, condition and availability from listing records instead of placeholders
- expand listing search filters for type, condition, features, and availability
- allow browsing search to match features

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898f3ae1e10832eb01ba79256db21b0