### PR TITLE
Use plural listings table name

### DIFF
--- a/add-listing-features.sql
+++ b/add-listing-features.sql
@@ -1,55 +1,54 @@
--- Add missing columns to listing table for new features
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS is_archived BOOLEAN DEFAULT FALSE;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS area DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS contact_number TEXT;
+-- Add missing columns to listings table for new features
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS is_archived BOOLEAN DEFAULT FALSE;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS area DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS contact_number TEXT;
 
 -- Add missing pricing columns
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS daily_rate DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS weekly_rate DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS monthly_rate DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS security_deposit DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS sell_price DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS is_for_sale BOOLEAN DEFAULT FALSE;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS is_for_rent BOOLEAN DEFAULT TRUE;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS daily_rate DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS weekly_rate DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS monthly_rate DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS security_deposit DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS sell_price DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS is_for_sale BOOLEAN DEFAULT FALSE;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS is_for_rent BOOLEAN DEFAULT TRUE;
 
 -- Add missing availability columns
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS available BOOLEAN DEFAULT TRUE;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS min_rental_days INTEGER DEFAULT 1;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS max_rental_days INTEGER DEFAULT 365;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS available BOOLEAN DEFAULT TRUE;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS min_rental_days INTEGER DEFAULT 1;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS max_rental_days INTEGER DEFAULT 365;
 
 -- Add missing location columns
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS location_address TEXT;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS location_city TEXT;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS location_state TEXT;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS location_zip_code TEXT;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS location_coordinates JSONB;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS location_address TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS location_city TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS location_state TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS location_zip_code TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS location_coordinates JSONB;
 
 -- Add missing size columns
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS size_height DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS size_width DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS size_depth DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS size_unit TEXT DEFAULT 'cm';
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS size_height DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS size_width DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS size_depth DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS size_unit TEXT DEFAULT 'cm';
 
 -- Add missing other columns
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS condition TEXT;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS host_name TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS condition TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS host_name TEXT;
 
 -- Update RLS policies to exclude archived listings from public view
-DROP POLICY IF EXISTS "Anyone can view available listings" ON listing;
-CREATE POLICY "Anyone can view available listings" ON listing
+DROP POLICY IF EXISTS "Anyone can view available listings" ON listings;
+CREATE POLICY "Anyone can view available listings" ON listings
   FOR SELECT USING (is_available = TRUE AND is_archived = FALSE);
 
 -- Allow hosts to view their archived listings
-DROP POLICY IF EXISTS "Hosts can view their own listings" ON listing;
-CREATE POLICY "Hosts can view their own listings" ON listing
+DROP POLICY IF EXISTS "Hosts can view their own listings" ON listings;
+CREATE POLICY "Hosts can view their own listings" ON listings
   FOR SELECT USING (auth.uid() = host_id);
 
--- Add archive function
 CREATE OR REPLACE FUNCTION archive_listing(listing_id UUID)
 RETURNS BOOLEAN AS $$
 BEGIN
-  UPDATE listing
+  UPDATE listings
   SET is_archived = TRUE,
       archived_at = NOW(),
       is_available = FALSE
@@ -59,11 +58,10 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
--- Add unarchive function
 CREATE OR REPLACE FUNCTION unarchive_listing(listing_id UUID)
 RETURNS BOOLEAN AS $$
 BEGIN
-  UPDATE listing
+  UPDATE listings
   SET is_archived = FALSE,
       archived_at = NULL,
       is_available = TRUE

--- a/check-table-structure.sql
+++ b/check-table-structure.sql
@@ -1,23 +1,23 @@
--- Check the current structure of the listing table
+-- Check the current structure of the listings table
 SELECT 
     column_name,
     data_type,
     is_nullable,
     column_default
 FROM information_schema.columns 
-WHERE table_name = 'listing' 
+WHERE table_name = 'listings'
 ORDER BY ordinal_position;
 
 -- Check if there are any existing records
-SELECT COUNT(*) as total_listings FROM listing;
+SELECT COUNT(*) as total_listings FROM listings;
 
 -- Check a sample record to see what data is actually stored
-SELECT * FROM listing LIMIT 1; 
+SELECT * FROM listings LIMIT 1;
 
--- Add missing columns to listing table
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS host_name TEXT;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS square_meters DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN DEFAULT FALSE;
+-- Add missing columns to listings table
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS host_name TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS square_meters DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN DEFAULT FALSE;
 
 -- Update existing records to set host_name based on owner_id
 -- (This will be populated when new listings are created) 

--- a/client/components/SupabaseDebugTest.tsx
+++ b/client/components/SupabaseDebugTest.tsx
@@ -17,7 +17,7 @@ export function SupabaseDebugTest() {
       // Test 1: Basic connection
       console.log("Test 1: Basic Supabase connection");
       const { data: healthData, error: healthError } = await supabase
-        .from("listing")
+        .from("listings")
         .select("*", { count: "exact", head: true });
 
       if (healthError) {
@@ -28,11 +28,11 @@ export function SupabaseDebugTest() {
         // Check if it's a table not found error
         if (
           healthError.message.includes(
-            'relation "public.listing" does not exist',
+            'relation "public.listings" does not exist',
           )
         ) {
           setStatus(
-            'Table "listing" does not exist - this is expected if database is not set up',
+            'Table "listings" does not exist - this is expected if database is not set up',
           );
         }
         return;
@@ -44,7 +44,7 @@ export function SupabaseDebugTest() {
       // Test 2: Try to fetch data
       console.log("Test 2: Fetching data");
       const { data, error } = await supabase
-        .from("listing")
+        .from("listings")
         .select("*")
         .limit(5);
 

--- a/client/contexts/ListingsContext.tsx
+++ b/client/contexts/ListingsContext.tsx
@@ -106,17 +106,17 @@ export function ListingsProvider({ children }: { children: ReactNode }) {
 
       // First check if table exists by doing a simple count query
       const { count, error: countError } = await supabase
-        .from("listing")
+        .from("listings")
         .select("*", { count: "exact", head: true });
 
       if (countError) {
         console.error("Table access error:", countError.message);
         if (
           countError.message.includes(
-            'relation "public.listing" does not exist',
+            'relation "public.listings" does not exist',
           )
         ) {
-          console.log("Listing table does not exist, using mock data");
+          console.log("Listings table does not exist, using mock data");
           setListings(getMockListings());
           return;
         }
@@ -124,7 +124,7 @@ export function ListingsProvider({ children }: { children: ReactNode }) {
 
       // If table exists, proceed with full query
       const { data, error } = await supabase
-        .from("listing")
+        .from("listings")
         .select("*")
         .order("created_at", { ascending: false });
 
@@ -351,7 +351,7 @@ export function ListingsProvider({ children }: { children: ReactNode }) {
     try {
       console.log("Adding listing to Supabase...");
       const { data, error } = await supabase
-        .from("listing")
+        .from("listings")
         .insert({
           host_id: listingData.hostId,
           host_name: listingData.hostName,
@@ -467,7 +467,7 @@ export function ListingsProvider({ children }: { children: ReactNode }) {
       }
 
       const { error } = await supabase
-        .from("listing")
+        .from("listings")
         .update(updateData)
         .eq("id", id);
 
@@ -498,7 +498,7 @@ export function ListingsProvider({ children }: { children: ReactNode }) {
 
   const deleteListing = async (id: string) => {
     try {
-      const { error } = await supabase.from("listing").delete().eq("id", id);
+      const { error } = await supabase.from("listings").delete().eq("id", id);
 
       if (error) {
         console.error("Error deleting listing:", error);

--- a/complete-listing-table.sql
+++ b/complete-listing-table.sql
@@ -1,64 +1,64 @@
--- Complete listing table structure with all required fields
--- This script will add all missing columns to the listing table
+-- Complete listings table structure with all required fields
+-- This script will add all missing columns to the listings table
 
--- Add all missing columns to listing table
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS host_name TEXT;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS square_meters DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN DEFAULT FALSE;
+-- Add all missing columns to listings table
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS host_name TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS square_meters DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN DEFAULT FALSE;
 
 -- Add category field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS category TEXT DEFAULT 'carry-on';
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS category TEXT DEFAULT 'carry-on';
 
 -- Add type field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS type TEXT DEFAULT 'hardside';
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS type TEXT DEFAULT 'hardside';
 
 -- Add condition field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS condition TEXT DEFAULT 'excellent';
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS condition TEXT DEFAULT 'excellent';
 
 -- Add features field (as JSON array)
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS features JSONB DEFAULT '[]';
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS features JSONB DEFAULT '[]';
 
 -- Add contact number field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS contact_number TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS contact_number TEXT;
 
 -- Add listing type field (rent/sale)
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS listing_type TEXT DEFAULT 'rent';
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS listing_type TEXT DEFAULT 'rent';
 
 -- Add weekly rate field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS weekly_rate DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS weekly_rate DECIMAL(10,2);
 
 -- Add monthly rate field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS monthly_rate DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS monthly_rate DECIMAL(10,2);
 
 -- Add security deposit field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS security_deposit DECIMAL(10,2) DEFAULT 50;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS security_deposit DECIMAL(10,2) DEFAULT 50;
 
 -- Add min rental days field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS min_rental_days INTEGER DEFAULT 1;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS min_rental_days INTEGER DEFAULT 1;
 
 -- Add max rental days field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS max_rental_days INTEGER DEFAULT 30;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS max_rental_days INTEGER DEFAULT 30;
 
 -- Add sell price field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS sell_price DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS sell_price DECIMAL(10,2);
 
 -- Add address field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS address TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS address TEXT;
 
 -- Add state field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS state TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS state TEXT;
 
 -- Add zip code field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS zip_code TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS zip_code TEXT;
 
 -- Add rating field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS rating DECIMAL(3,2) DEFAULT 0;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS rating DECIMAL(3,2) DEFAULT 0;
 
 -- Add review count field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS review_count INTEGER DEFAULT 0;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS review_count INTEGER DEFAULT 0;
 
 -- Add available field
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS available BOOLEAN DEFAULT TRUE;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS available BOOLEAN DEFAULT TRUE;
 
 -- Success message
-SELECT 'All columns added successfully to listing table!' as status; 
+SELECT 'All columns added successfully to listings table!' as status;

--- a/complete-setup.sql
+++ b/complete-setup.sql
@@ -1,11 +1,11 @@
 -- Complete setup script that safely handles all existing policies
 -- This script will drop all existing policies and recreate them
 
--- Drop existing policies for listing table (if they exist)
-DROP POLICY IF EXISTS "Anyone can view listings" ON listing;
-DROP POLICY IF EXISTS "Authenticated users can create listings" ON listing;
-DROP POLICY IF EXISTS "Users can update their own listings" ON listing;
-DROP POLICY IF EXISTS "Users can delete their own listings" ON listing;
+-- Drop existing policies for listings table (if they exist)
+DROP POLICY IF EXISTS "Anyone can view listings" ON listings;
+DROP POLICY IF EXISTS "Authenticated users can create listings" ON listings;
+DROP POLICY IF EXISTS "Users can update their own listings" ON listings;
+DROP POLICY IF EXISTS "Users can delete their own listings" ON listings;
 
 -- Drop existing policies for listing_images table (if they exist)
 DROP POLICY IF EXISTS "Anyone can view listing images" ON listing_images;
@@ -19,17 +19,17 @@ DROP POLICY IF EXISTS "Authenticated users can upload listing images" ON storage
 DROP POLICY IF EXISTS "Users can update their own listing images" ON storage.objects;
 DROP POLICY IF EXISTS "Users can delete their own listing images" ON storage.objects;
 
--- Create policies for listing table
-CREATE POLICY "Anyone can view listings" ON listing
+-- Create policies for listings table
+CREATE POLICY "Anyone can view listings" ON listings
   FOR SELECT USING (true);
 
-CREATE POLICY "Authenticated users can create listings" ON listing
+CREATE POLICY "Authenticated users can create listings" ON listings
   FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
 
-CREATE POLICY "Users can update their own listings" ON listing
+CREATE POLICY "Users can update their own listings" ON listings
   FOR UPDATE USING (auth.uid() = owner_id);
 
-CREATE POLICY "Users can delete their own listings" ON listing
+CREATE POLICY "Users can delete their own listings" ON listings
   FOR DELETE USING (auth.uid() = owner_id);
 
 -- Create policies for listing_images table
@@ -40,27 +40,27 @@ CREATE POLICY "Users can add images to their own listings" ON listing_images
   FOR INSERT WITH CHECK (
     auth.uid() IS NOT NULL AND
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 
 CREATE POLICY "Users can update images for their own listings" ON listing_images
   FOR UPDATE USING (
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 
 CREATE POLICY "Users can delete images from their own listings" ON listing_images
   FOR DELETE USING (
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 
@@ -86,10 +86,10 @@ CREATE POLICY "Users can delete their own listing images" ON storage.objects
     AND auth.uid()::text = (storage.foldername(name))[1]
   );
 
--- Add missing columns to listing table
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS host_name TEXT;
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS square_meters DECIMAL(10,2);
-ALTER TABLE listing ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN DEFAULT FALSE;
+-- Add missing columns to listings table
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS host_name TEXT;
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS square_meters DECIMAL(10,2);
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN DEFAULT FALSE;
 
 -- Success message
 SELECT 'All policies created successfully!' as status; 

--- a/create-listing-images-table.sql
+++ b/create-listing-images-table.sql
@@ -1,7 +1,7 @@
 -- Create listing_images table
 CREATE TABLE IF NOT EXISTS listing_images (
   id SERIAL PRIMARY KEY,
-  listing_id INTEGER NOT NULL REFERENCES listing(id) ON DELETE CASCADE,
+  listing_id INTEGER NOT NULL REFERENCES listings(id) ON DELETE CASCADE,
   image_url TEXT NOT NULL,
   order_index INTEGER NOT NULL DEFAULT 0,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
@@ -24,9 +24,9 @@ CREATE POLICY "Users can add images to their own listings" ON listing_images
   FOR INSERT WITH CHECK (
     auth.uid() IS NOT NULL AND
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 
@@ -34,9 +34,9 @@ CREATE POLICY "Users can add images to their own listings" ON listing_images
 CREATE POLICY "Users can update images for their own listings" ON listing_images
   FOR UPDATE USING (
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 
@@ -44,9 +44,9 @@ CREATE POLICY "Users can update images for their own listings" ON listing_images
 CREATE POLICY "Users can delete images from their own listings" ON listing_images
   FOR DELETE USING (
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 

--- a/disable-rls.sql
+++ b/disable-rls.sql
@@ -1,2 +1,2 @@
--- Отключить RLS для таблицы listing
-ALTER TABLE listing DISABLE ROW LEVEL SECURITY; 
+-- Отключить RLS для таблицы listings
+ALTER TABLE listings DISABLE ROW LEVEL SECURITY;

--- a/fix-existing-policies.sql
+++ b/fix-existing-policies.sql
@@ -1,11 +1,11 @@
 -- Safe SQL script that handles existing policies
 -- This script will drop existing policies and recreate them
 
--- Drop existing policies for listing table (if they exist)
-DROP POLICY IF EXISTS "Anyone can view listings" ON listing;
-DROP POLICY IF EXISTS "Authenticated users can create listings" ON listing;
-DROP POLICY IF EXISTS "Users can update their own listings" ON listing;
-DROP POLICY IF EXISTS "Users can delete their own listings" ON listing;
+-- Drop existing policies for listings table (if they exist)
+DROP POLICY IF EXISTS "Anyone can view listings" ON listings;
+DROP POLICY IF EXISTS "Authenticated users can create listings" ON listings;
+DROP POLICY IF EXISTS "Users can update their own listings" ON listings;
+DROP POLICY IF EXISTS "Users can delete their own listings" ON listings;
 
 -- Drop existing policies for listing_images table (if they exist)
 DROP POLICY IF EXISTS "Anyone can view listing images" ON listing_images;
@@ -19,10 +19,9 @@ DROP POLICY IF EXISTS "Authenticated users can upload listing images" ON storage
 DROP POLICY IF EXISTS "Users can update their own listing images" ON storage.objects;
 DROP POLICY IF EXISTS "Users can delete their own listing images" ON storage.objects;
 
--- Create listing_images table if it doesn't exist
 CREATE TABLE IF NOT EXISTS listing_images (
   id SERIAL PRIMARY KEY,
-  listing_id INTEGER NOT NULL REFERENCES listing(id) ON DELETE CASCADE,
+  listing_id INTEGER NOT NULL REFERENCES listings(id) ON DELETE CASCADE,
   image_url TEXT NOT NULL,
   order_index INTEGER NOT NULL DEFAULT 0,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
@@ -36,17 +35,17 @@ CREATE INDEX IF NOT EXISTS idx_listing_images_order ON listing_images(listing_id
 -- Enable RLS for listing_images
 ALTER TABLE listing_images ENABLE ROW LEVEL SECURITY;
 
--- Create policies for listing table
-CREATE POLICY "Anyone can view listings" ON listing
+-- Create policies for listings table
+CREATE POLICY "Anyone can view listings" ON listings
   FOR SELECT USING (true);
 
-CREATE POLICY "Authenticated users can create listings" ON listing
+CREATE POLICY "Authenticated users can create listings" ON listings
   FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
 
-CREATE POLICY "Users can update their own listings" ON listing
+CREATE POLICY "Users can update their own listings" ON listings
   FOR UPDATE USING (auth.uid() = owner_id);
 
-CREATE POLICY "Users can delete their own listings" ON listing
+CREATE POLICY "Users can delete their own listings" ON listings
   FOR DELETE USING (auth.uid() = owner_id);
 
 -- Create policies for listing_images table
@@ -57,27 +56,27 @@ CREATE POLICY "Users can add images to their own listings" ON listing_images
   FOR INSERT WITH CHECK (
     auth.uid() IS NOT NULL AND
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 
 CREATE POLICY "Users can update images for their own listings" ON listing_images
   FOR UPDATE USING (
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 
 CREATE POLICY "Users can delete images from their own listings" ON listing_images
   FOR DELETE USING (
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 

--- a/fix-rls-policies.sql
+++ b/fix-rls-policies.sql
@@ -1,20 +1,20 @@
--- Включить RLS для таблицы listing
-ALTER TABLE listing ENABLE ROW LEVEL SECURITY;
+-- Включить RLS для таблицы listings
+ALTER TABLE listings ENABLE ROW LEVEL SECURITY;
 
 -- Политика для просмотра всех объявлений
-CREATE POLICY "Anyone can view listings" ON listing
+CREATE POLICY "Anyone can view listings" ON listings
   FOR SELECT USING (true);
 
 -- Политика для создания объявлений (только аутентифицированные пользователи)
-CREATE POLICY "Authenticated users can create listings" ON listing
+CREATE POLICY "Authenticated users can create listings" ON listings
   FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
 
 -- Политика для обновления объявлений (только владелец)
-CREATE POLICY "Users can update their own listings" ON listing
+CREATE POLICY "Users can update their own listings" ON listings
   FOR UPDATE USING (auth.uid() = owner_id);
 
 -- Политика для удаления объявлений (только владелец)
-CREATE POLICY "Users can delete their own listings" ON listing
+CREATE POLICY "Users can delete their own listings" ON listings
   FOR DELETE USING (auth.uid() = owner_id); 
 
 -- Allow anyone to view images

--- a/update-listing-images-table.sql
+++ b/update-listing-images-table.sql
@@ -58,27 +58,27 @@ CREATE POLICY "Users can add images to their own listings" ON listing_images
   FOR INSERT WITH CHECK (
     auth.uid() IS NOT NULL AND
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 
 CREATE POLICY "Users can update images for their own listings" ON listing_images
   FOR UPDATE USING (
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 
 CREATE POLICY "Users can delete images from their own listings" ON listing_images
   FOR DELETE USING (
     EXISTS (
-      SELECT 1 FROM listing 
-      WHERE listing.id = listing_images.listing_id 
-      AND listing.owner_id = auth.uid()
+      SELECT 1 FROM listings
+      WHERE listings.id = listing_images.listing_id
+      AND listings.owner_id = auth.uid()
     )
   );
 


### PR DESCRIPTION
## Summary
- Switch client Supabase queries to use the `listings` table
- Align SQL scripts with `listings` table naming

## Testing
- `npm test`
- `npm run typecheck` *(fails: Type '"sqm"' is not assignable to type '"cm" | "inches"')*

------
https://chatgpt.com/codex/tasks/task_e_6899219a63a8832eaeebf37ac6640e3f